### PR TITLE
Use LinkedHashMap for keeping insertion order in IxToMap

### DIFF
--- a/src/main/java/ix/IxToMap.java
+++ b/src/main/java/ix/IxToMap.java
@@ -55,7 +55,7 @@ final class IxToMap<T, K, V> extends IxSource<T, Map<K, V>> {
 
             IxFunction<? super T, ? extends V> valueSelector = this.valueSelector;
 
-            Map<K, V> result = new HashMap<K, V>();
+            Map<K, V> result = new LinkedHashMap<K, V>();
 
             while (it.hasNext()) {
                 T t = it.next();


### PR DESCRIPTION
In order to keep insertion order on filling map in IxToMap, suggested to user LinkedHashMap for that purpose.