### PR TITLE
add Ix.fromSuppliers

### DIFF
--- a/src/main/java/ix/Ix.java
+++ b/src/main/java/ix/Ix.java
@@ -258,6 +258,26 @@ public abstract class Ix<T> implements Iterable<T> {
     }
 
     /**
+     * Emits all the elements of the given suppliers array.
+     * <p>
+     * The result's iterator() doesn't support remove().
+     * <p>
+     * 
+     * @param <T> the value type
+     * @param values the array of suppliers of values, not null
+     * @return the new Ix instance
+     * @throws NullPointerException if values is null
+     * @since 1.x
+     */
+    public static <T> Ix<T> fromSuppliers(IxSupplier<T>... values) {
+        int n = values.length;
+        if (n == 0) {
+            return empty();
+        }
+        return new IxFromSuppliers<T>(0,values.length,values);
+    }
+
+    /**
      * Generates a sequence of values via a generic indexed for-loop style construct;
      * the index starts with the given seed, checked via a condition (to terminate),
      * generated from the index via the selector and then a new index is generated via next.

--- a/src/main/java/ix/IxFromSuppliers.java
+++ b/src/main/java/ix/IxFromSuppliers.java
@@ -1,0 +1,57 @@
+package ix;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+public class IxFromSuppliers<T> extends Ix<T> {
+
+    final int start;
+    final int end;
+    final IxSupplier<T>[] array;
+
+    IxFromSuppliers(int start, int end, IxSupplier<T>[] array) {
+        this.start = start;
+        this.end = end;
+        this.array = array;
+    }
+
+    @Override
+    public Iterator<T> iterator() {
+        return new FromSuppliers<T>(start, end, array);
+    }
+
+    static final class FromSuppliers<T> implements Iterator<T> {
+        final IxSupplier<T>[] array;
+
+        final int end;
+
+        int index;
+
+        FromSuppliers(int start, int end, IxSupplier<T>[] array) {
+            this.index = start;
+            this.end = end;
+            this.array = array;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return index != end;
+        }
+
+        @Override
+        public T next() {
+            int i = index;
+            if (i != end) {
+                index = i + 1;
+                return array[i].get();
+            }
+            throw new NoSuchElementException();
+        }
+
+        @Override
+        public void remove() {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+}

--- a/src/test/java/ix/FromSuppliersTest.java
+++ b/src/test/java/ix/FromSuppliersTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2011-2016 David Karnok
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ix;
+
+import org.junit.*;
+
+public class FromSuppliersTest {
+
+	@Test
+	public void normal() {
+		IxSupplier<Integer> _1 = new IxSupplier<Integer>() {
+			@Override
+			public Integer get() {
+				return 1;
+			}
+		};
+		IxSupplier<Integer> _2 = new IxSupplier<Integer>() {
+			@Override
+			public Integer get() {
+				return 2;
+			}
+		};
+		IxSupplier<Integer> _3 = new IxSupplier<Integer>() {
+			@Override
+			public Integer get() {
+				return 3;
+			}
+		};
+		Ix<Integer> source = Ix.fromSuppliers(_1,_2,_3);
+
+		IxTestHelper.assertValues(source, 1, 2, 3);
+
+		IxTestHelper.assertNoRemove(source);
+	}
+
+	@Test
+	public void empty() {
+		Ix<Integer> source = Ix.fromArray();
+
+		Assert.assertSame(source.getClass().toString(), source, Ix.empty());
+	}
+
+}


### PR DESCRIPTION
This provides simplified constructor for `IxSuppliers<T>`.

This makes more easier to build `Ix<T>` from `Suppiers<T>` , like:
``` java
for(Result result: Ix.fromSuppliers( requestA::get , requestB::get, requestC::get )){
  // request*.get() may use many computing resources.
  resultConsumer.accept(result);
}
``` 
or ` Ix.fromSuppliers( requestA::get , requestB::get, requestC::get  ).subscribe(resultConsumer::accept);` 

I know that it can be substituted by `Ix.forloop`, but I think this makes production codes more simpler or readable in some cases.